### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/src/components/mushaf/FloatingAudioPlayer.tsx
+++ b/src/components/mushaf/FloatingAudioPlayer.tsx
@@ -217,6 +217,7 @@ export default function FloatingAudioPlayer({
             onClick={isPlaying ? onPause : onPlay}
             className="w-20 h-20 flex-shrink-0 flex items-center justify-center rounded-full bg-gradient-to-br from-primary to-primary/90 text-primary-foreground shadow-[0_10px_30px_-10px_rgba(var(--color-primary-rgb),0.8),inset_0_2px_4px_rgba(255,255,255,0.3)] hover:shadow-[0_15px_35px_-10px_rgba(var(--color-primary-rgb),0.9),inset_0_2px_4px_rgba(255,255,255,0.3)] hover:-translate-y-1 active:translate-y-0.5 active:scale-95 transition-all duration-300 outline-none"
             title={isPlaying ? t.mushaf.pause : t.mushaf.audio}
+            aria-label={isPlaying ? t.mushaf.pause : t.mushaf.audio}
           >
             {isPlaying ? (
               <Pause size={34} fill="currentColor" className="animate-in fade-in zoom-in duration-300" />

--- a/src/components/mushaf/MushafViewer.tsx
+++ b/src/components/mushaf/MushafViewer.tsx
@@ -376,6 +376,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               className="absolute -top-3 -end-3 bg-red-500 text-white rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-5 h-5 shadow-sm"
               style={{ zIndex: 60 }}
               title={locale === "ar" ? "حذف الملاحظة" : "Delete Annotation"}
+              aria-label={locale === "ar" ? "حذف الملاحظة" : "Delete Annotation"}
             >
               <Trash2 size={12} strokeWidth={3} />
             </button>

--- a/src/components/mushaf/ui/MushafCloseButton.tsx
+++ b/src/components/mushaf/ui/MushafCloseButton.tsx
@@ -13,6 +13,7 @@ const MushafCloseButton = forwardRef<HTMLButtonElement, MushafCloseButtonProps>(
             <button
                 ref={ref}
                 title={title}
+                aria-label={title}
                 className={`p-2 rounded-xl text-muted-foreground transition-all duration-300 ease-out cursor-pointer active:scale-90 hover:bg-destructive/10 hover:text-destructive group outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 ${className}`.trim()}
                 {...props}
             >


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to icon-only buttons across multiple components (`FloatingAudioPlayer.tsx`, `MushafViewer.tsx`, and `MushafCloseButton.tsx`) to match their existing `title` values.

🎯 **Why:** To improve screen reader accessibility, ensuring that users relying on assistive technologies can understand the purpose of these icon-only buttons. This is a crucial UX improvement that makes the application more inclusive.

📸 **Before/After:** N/A (No visual changes)

♿ **Accessibility:** This directly addresses accessibility by providing programmatic labels for interactive elements that previously lacked text content. Screen readers will now announce these actions appropriately.

---
*PR created automatically by Jules for task [1566049336086134825](https://jules.google.com/task/1566049336086134825) started by @AHKH3*