### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-29 - Add ARIA Labels to Icon-Only Buttons
+**Learning:** In standard icon-only buttons (e.g. Pin, Collapse, Erase), adding `aria-label` using the same text as the `title` property significantly improves screen reader accessibility with no visual regression.
+**Action:** Always add `aria-label` to any icon button that lacks visible text.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-04-29 - Add ARIA Labels to Icon-Only Buttons
+**Learning:** In standard icon-only buttons (e.g. Pin, Collapse, Erase), adding `aria-label` using the same text as the `title` property significantly improves screen reader accessibility with no visual regression.
+**Action:** Always add `aria-label` to any icon button that lacks visible text.
+
 ## 2026-06-07 - MushafButton Accessibility Insights
 **Learning:** Found that custom reusable UI elements often lack robust fallback accessibility attributes natively provided by semantic HTML.
 **Action:** When building reusable UI elements (e.g., `MushafButton`), map `title` to `aria-label` as a fallback and visual active props to `aria-pressed` to guarantee accessibility for screen readers and semantic ARIA translation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6820,7 +6820,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/mushaf/FloatingPanel.tsx
+++ b/src/components/mushaf/FloatingPanel.tsx
@@ -184,6 +184,7 @@ export default function FloatingPanel({
                     onClick={(e) => { e.stopPropagation(); togglePin(); }}
                     className={`p-1.5 rounded-lg transition-colors h-auto w-auto shadow-none border-transparent ${isPinned ? "bg-primary/20 text-primary hover:bg-primary/30" : "hover:bg-accent text-muted-foreground hover:text-foreground bg-transparent"}`}
                     title={pinTitle}
+                    aria-label={pinTitle}
                     icon={isPinned ? <PinOff size={15} /> : <Pin size={15} />}
                   />
                   <MushafButton
@@ -191,6 +192,7 @@ export default function FloatingPanel({
                     onClick={(e) => { e.stopPropagation(); handleCollapse(); }}
                     className="p-1.5 rounded-xl hover:bg-muted/80 transition-all text-muted-foreground hover:text-foreground h-auto w-auto shadow-none border-transparent bg-transparent"
                     title={collapseTitle}
+                    aria-label={collapseTitle}
                     icon={<ChevronDown size={18} />}
                   />
                   </>
@@ -443,6 +445,7 @@ export default function FloatingPanel({
             onClick={(e) => { e.stopPropagation(); togglePin(); }}
             className={`p-1.5 rounded-lg transition-colors h-auto w-auto shadow-none border-transparent ${isPinned ? "bg-primary/20 text-primary hover:bg-primary/30" : "hover:bg-accent text-muted-foreground hover:text-foreground bg-transparent"}`}
             title={pinTitle}
+            aria-label={pinTitle}
             icon={isPinned ? <PinOff size={13} /> : <Pin size={13} />}
           />
 
@@ -453,6 +456,7 @@ export default function FloatingPanel({
             onClick={(e) => { e.stopPropagation(); handleCollapse(); }}
             className="p-1.5 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground h-auto w-auto shadow-none border-transparent bg-transparent"
             title={collapseTitle}
+            aria-label={collapseTitle}
             icon={<ChevronDown size={13} />}
           />
 

--- a/src/components/mushaf/MushafViewer.tsx
+++ b/src/components/mushaf/MushafViewer.tsx
@@ -376,6 +376,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               className="absolute -top-3 -end-3 bg-red-500 text-white rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-5 h-5 shadow-sm"
               style={{ zIndex: 60 }}
               title={locale === "ar" ? "حذف الملاحظة" : "Delete Annotation"}
+              aria-label={locale === "ar" ? "حذف الملاحظة" : "Delete Annotation"}
             >
               <Trash2 size={12} strokeWidth={3} />
             </button>
@@ -1561,6 +1562,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
                 <button
                   onClick={() => clearTemporaryAnnotations()}
                   title={locale === "ar" ? "مسح التحديد المؤقت" : "Clear Temp Highlights"}
+                  aria-label={locale === "ar" ? "مسح التحديد المؤقت" : "Clear Temp Highlights"}
                   className="p-1.5 text-xs font-medium bg-background border border-border/50 hover:bg-muted/50 text-muted-foreground hover:text-red-500 rounded shadow-sm transition-colors me-1"
                 >
                   <Eraser size={14} />

--- a/src/components/mushaf/MushafViewer.tsx
+++ b/src/components/mushaf/MushafViewer.tsx
@@ -1562,6 +1562,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
                 <button
                   onClick={() => clearTemporaryAnnotations()}
                   title={locale === "ar" ? "مسح التحديد المؤقت" : "Clear Temp Highlights"}
+                  aria-label={locale === "ar" ? "مسح التحديد المؤقت" : "Clear Temp Highlights"}
                   className="p-1.5 text-xs font-medium bg-background border border-border/50 hover:bg-muted/50 text-muted-foreground hover:text-red-500 rounded shadow-sm transition-colors me-1"
                 >
                   <Eraser size={14} />


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons in `MushafViewer` (clear temporary annotations, delete annotation) and `FloatingPanel` (pin, collapse).
🎯 Why: Ensures screen reader compatibility for core functionality by explicitly describing the action for non-sighted users.
📸 Before/After: Visuals remain unchanged; DOM elements now include semantic accessibility tags.
♿ Accessibility: Improves keyboard and screen reader accessibility for icon-centric controls by supplying a programmatically identifiable label.

---
*PR created automatically by Jules for task [7562450499026574739](https://jules.google.com/task/7562450499026574739) started by @AHKH3*