### PR TITLE
🎨 Palette: Improve accessibility of login form inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - [Add htmlFor and id to Form Inputs for Accessibility]
+**Learning:** Found that custom input components, like `EngravedInput` in this app, were not always properly associated with their labels using `htmlFor` and `id` properties. This prevents screen readers from announcing the label when the input receives focus and breaks clicking the label to focus the input.
+**Action:** Always ensure that form inputs have proper `id` properties and that their associated labels have matching `htmlFor` properties. When creating custom form components, make sure they support passing down the `id` prop to the native input element.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -78,11 +78,12 @@ export default function LoginPage() {
               )}
 
               <div>
-                <label className="block text-sm font-medium mb-1.5">
+                <label htmlFor="email" className="block text-sm font-medium mb-1.5">
                   {t.login.email}
                 </label>
                 <div className="relative">
                   <EngravedInput
+                    id="email"
                     type="email"
                     value={email}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
@@ -96,11 +97,12 @@ export default function LoginPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-1.5">
+                <label htmlFor="password" className="block text-sm font-medium mb-1.5">
                   {t.login.password}
                 </label>
                 <div className="relative">
                   <EngravedInput
+                    id="password"
                     type="password"
                     value={password}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}


### PR DESCRIPTION
💡 What: Added `htmlFor` properties to the `label` elements and matching `id` properties to the `EngravedInput` elements on the login page (`src/app/login/page.tsx`).

🎯 Why: To improve the user experience by allowing users to click the labels to focus the corresponding input fields, a standard and expected interaction.

📸 Before/After: Visuals remain exactly the same. The difference is behavioral (clicking the label now focuses the input).

♿ Accessibility: This change creates a programmatic association between the labels and their respective inputs, ensuring screen readers can correctly announce the field's purpose when it receives focus.

---
*PR created automatically by Jules for task [9965746603698001373](https://jules.google.com/task/9965746603698001373) started by @AHKH3*