### PR TITLE
🎨 Palette: Add ARIA label to delete student button

### DIFF
--- a/src/app/mushaf/students/page.tsx
+++ b/src/app/mushaf/students/page.tsx
@@ -186,6 +186,8 @@ export default function StudentsPage() {
                   </Link>
                   <button
                     onClick={() => deleteStudent(student.id)}
+                    aria-label={t.common.delete}
+                    title={t.common.delete}
                     className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
                   >
                     <Trash2 size={16} />


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to the "delete student" icon-only button in the students page (`src/app/mushaf/students/page.tsx`).
🎯 **Why:** To improve accessibility for screen readers and provide a helpful tooltip for mouse users who might not understand what the trash icon does immediately.
📸 **Before/After:** The button now explicitly states its purpose (`t.common.delete` -> "Delete" or "حذف") using ARIA properties.
♿ **Accessibility:** Provides clear semantic meaning to an icon-only control.

---
*PR created automatically by Jules for task [7678472012436769140](https://jules.google.com/task/7678472012436769140) started by @AHKH3*