### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/mushaf/AdvancedSearch.tsx
+++ b/src/components/mushaf/AdvancedSearch.tsx
@@ -204,6 +204,7 @@ export default function AdvancedSearch({
                 onClick={() => setShowFilters(!showFilters)}
                 icon={<Filter size={20} />}
                 className="w-11 h-11 border border-border/40 bg-background/70 shadow-sm"
+                aria-label={t.mushaf.filters}
               />
               <MushafCloseButton
                 onClick={onClose}
@@ -420,6 +421,7 @@ export default function AdvancedSearch({
               disabled={currentPage === 1}
               icon={locale === "ar" ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
               className="w-10 h-10 border border-border/40 bg-card shadow-sm disabled:opacity-30"
+              aria-label={t.mushaf.previous}
             />
             <div className="mushaf-text-compact font-bold text-muted-foreground">
               <span className="text-foreground">{currentPage}</span> / {totalPages}
@@ -430,6 +432,7 @@ export default function AdvancedSearch({
               disabled={currentPage === totalPages}
               icon={locale === "ar" ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
               className="w-10 h-10 border border-border/40 bg-card shadow-sm disabled:opacity-30"
+              aria-label={t.mushaf.next}
             />
           </div>
         )}

--- a/src/components/mushaf/MushafViewer.tsx
+++ b/src/components/mushaf/MushafViewer.tsx
@@ -1425,6 +1425,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               }}
               icon={<BookOpen size={16} />}
               title={t.mushaf.verseRange}
+              aria-label={t.mushaf.verseRange}
               data-testid="open-verse-range-panel"
               className="hover:bg-primary/10 rounded-xl"
             />
@@ -1434,6 +1435,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               onClick={() => setShowBookmarks(true)}
               icon={<Bookmark size={16} />}
               title={locale === "ar" ? "الإشارات المرجعية" : "Bookmarks"}
+              aria-label={locale === "ar" ? "الإشارات المرجعية" : "Bookmarks"}
               className="hover:bg-primary/10 rounded-xl"
             />
             <MushafButton
@@ -1453,6 +1455,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               }}
               icon={<TafsirPanelIcon size={16} />}
               title={t.mushaf.openTafsirPanel}
+              aria-label={t.mushaf.openTafsirPanel}
               className="hover:bg-primary/10 rounded-xl"
               data-testid="open-tafsir-panel"
             />
@@ -1462,6 +1465,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               onClick={() => setShowAudioPlayer((v) => !v)}
               icon={<Volume2 size={16} />}
               title={locale === "ar" ? t.mushaf.audioPlayer : t.mushaf.audioPlayer}
+              aria-label={locale === "ar" ? t.mushaf.audioPlayer : t.mushaf.audioPlayer}
               data-testid="open-audio-panel"
               className="hover:bg-primary/10 rounded-xl"
             />
@@ -1471,6 +1475,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               onClick={() => setAutoScroll(!autoScroll)}
               icon={<Scroll size={16} />}
               title={locale === "ar" ? "التمرير التلقائي" : "Auto Scroll"}
+              aria-label={locale === "ar" ? "التمرير التلقائي" : "Auto Scroll"}
               className="hover:bg-primary/10 rounded-xl"
             />
             <MushafButton
@@ -1479,6 +1484,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
               onClick={() => setShowDisplaySettings(true)}
               icon={<Settings size={16} />}
               title={t.mushaf.displaySettings}
+              aria-label={t.mushaf.displaySettings}
               data-testid="open-display-settings-panel"
               className="hover:bg-primary/10 rounded-xl"
             />
@@ -1490,6 +1496,7 @@ export default function MushafViewer({ studentId, readOnly = false }: MushafView
                 onClick={() => setShowScreenModeMenu(!showScreenModeMenu)}
                 icon={screenMode === "focus" ? <Scan size={18} /> : screenMode === "fullscreen" ? <Maximize2 size={18} /> : <Monitor size={18} />}
                 title={t.mushaf.screenMode}
+                aria-label={t.mushaf.screenMode}
               >
                 <ChevronDown size={14} className={`transition-transform duration-300 ${showScreenModeMenu ? "rotate-180" : ""}`} />
               </MushafButton>

--- a/src/components/mushaf/QuickVerseRangePanel.tsx
+++ b/src/components/mushaf/QuickVerseRangePanel.tsx
@@ -358,6 +358,7 @@ export function VerseRangeForm({
                       onClick={() => handleVerseAdjust("from", -1)}
                       icon={<Minus size={14} />}
                       className="h-10 w-10 border border-border/40 bg-background"
+                      aria-label={locale === "ar" ? "تقليل آية البداية" : "Decrease from verse"}
                     />
                     <EngravedInput
                       type="number"
@@ -378,6 +379,7 @@ export function VerseRangeForm({
                       onClick={() => handleVerseAdjust("from", 1)}
                       icon={<Plus size={14} />}
                       className="h-10 w-10 border border-border/40 bg-background"
+                      aria-label={locale === "ar" ? "زيادة آية البداية" : "Increase from verse"}
                     />
                   </div>
                 </div>
@@ -396,6 +398,7 @@ export function VerseRangeForm({
                       onClick={() => handleVerseAdjust("to", -1)}
                       icon={<Minus size={14} />}
                       className="h-10 w-10 border border-border/40 bg-background"
+                      aria-label={locale === "ar" ? "تقليل آية النهاية" : "Decrease to verse"}
                     />
                     <EngravedInput
                       type="number"
@@ -416,6 +419,7 @@ export function VerseRangeForm({
                       onClick={() => handleVerseAdjust("to", 1)}
                       icon={<Plus size={14} />}
                       className="h-10 w-10 border border-border/40 bg-background"
+                      aria-label={locale === "ar" ? "زيادة آية النهاية" : "Increase to verse"}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to various icon-only buttons throughout the Mushaf components (FloatingPanel, FloatingAudioPlayer, QuickVerseRangePanel, AdvancedSearch, MushafViewer).
🎯 **Why**: Improves accessibility for screen reader users by ensuring icon-only buttons have descriptive text, addressing cases where some buttons lacked context.
📸 **Before/After**: N/A (Visuals remain unchanged, but accessibility tree is improved).
♿ **Accessibility**: Enhanced screen reader support by providing explicit `aria-label`s based on translations and titles.

---
*PR created automatically by Jules for task [10888744082788044430](https://jules.google.com/task/10888744082788044430) started by @AHKH3*