### PR TITLE
🎨 Palette: Add missing `aria-controls` to expandable settings

### DIFF
--- a/src/components/mushaf/DisplaySettings.tsx
+++ b/src/components/mushaf/DisplaySettings.tsx
@@ -175,6 +175,7 @@ export default function DisplaySettings({
                 onClick={() => setMobileSection("font")}
                 className="w-full flex items-center justify-between"
                 aria-expanded={shouldShow("font")}
+                aria-controls="font-settings-content"
               >
                 <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
                   <Type size={16} className="text-muted-foreground" />
@@ -182,7 +183,7 @@ export default function DisplaySettings({
                 </span>
                 <ChevronDown size={16} className={`sm:hidden text-muted-foreground transition-transform ${shouldShow("font") ? "rotate-180" : ""}`} />
               </button>
-              <div className={`${shouldShow("font") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
+              <div id="font-settings-content" className={`${shouldShow("font") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
                 <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-label={t.mushaf.fontSize}>
                   {fontSizes.map((size) => {
                     const isActive = fontSize === size.value;
@@ -214,6 +215,7 @@ export default function DisplaySettings({
                 onClick={() => setMobileSection("width")}
                 className="w-full flex items-center justify-between"
                 aria-expanded={shouldShow("width")}
+                aria-controls="width-settings-content"
               >
                 <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
                   <Monitor size={16} className="text-muted-foreground" />
@@ -221,7 +223,7 @@ export default function DisplaySettings({
                 </span>
                 <ChevronDown size={16} className={`sm:hidden text-muted-foreground transition-transform ${shouldShow("width") ? "rotate-180" : ""}`} />
               </button>
-              <div className={`${shouldShow("width") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
+              <div id="width-settings-content" className={`${shouldShow("width") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
                 <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label={t.mushaf.pageWidth}>
                   {pageWidths.map((width) => {
                     const isActive = pageWidth === width.value;
@@ -254,6 +256,7 @@ export default function DisplaySettings({
                 onClick={() => setMobileSection("reading")}
                 className="w-full flex items-center justify-between"
                 aria-expanded={shouldShow("reading")}
+                aria-controls="reading-settings-content"
               >
                 <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
                   <Palette size={16} className="text-muted-foreground" />
@@ -261,7 +264,7 @@ export default function DisplaySettings({
                 </span>
                 <ChevronDown size={16} className={`sm:hidden text-muted-foreground transition-transform ${shouldShow("reading") ? "rotate-180" : ""}`} />
               </button>
-              <div className={`${shouldShow("reading") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
+              <div id="reading-settings-content" className={`${shouldShow("reading") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-2" role="radiogroup" aria-label={t.mushaf.readingMode}>
                   {readingModes.map((mode) => {
                     const isActive = readingMode === mode.value;
@@ -313,6 +316,7 @@ export default function DisplaySettings({
                 onClick={() => setMobileSection("preview")}
                 className="w-full flex items-center justify-between"
                 aria-expanded={shouldShow("preview")}
+                aria-controls="preview-settings-content"
               >
                 <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
                   <Eye size={16} className="text-muted-foreground" />
@@ -320,7 +324,7 @@ export default function DisplaySettings({
                 </span>
                 <ChevronDown size={16} className={`sm:hidden text-muted-foreground transition-transform ${shouldShow("preview") ? "rotate-180" : ""}`} />
               </button>
-              <div className={`${shouldShow("preview") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
+              <div id="preview-settings-content" className={`${shouldShow("preview") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
                 <div
                   className={`mx-auto w-full ${previewWidthClass} rounded-xl border p-4 transition-all duration-300`}
                   style={{
@@ -342,6 +346,7 @@ export default function DisplaySettings({
                 onClick={() => setMobileSection("shortcuts")}
                 className="w-full flex items-center justify-between"
                 aria-expanded={shouldShow("shortcuts")}
+                aria-controls="shortcuts-settings-content"
               >
                 <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
                   <Keyboard size={16} className="text-muted-foreground" />
@@ -352,7 +357,7 @@ export default function DisplaySettings({
                 </span>
                 <ChevronDown size={16} className={`sm:hidden text-muted-foreground transition-transform ${shouldShow("shortcuts") ? "rotate-180" : ""}`} />
               </button>
-              <div className={`${shouldShow("shortcuts") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
+              <div id="shortcuts-settings-content" className={`${shouldShow("shortcuts") ? "mt-3 block" : "hidden"} sm:block sm:mt-3`}>
                 <div className="space-y-2.5">
                   {MUSHAF_SHORTCUTS.map((shortcut) => {
                     const shortLabel = SHORTCUT_LABELS[shortcut.id];

--- a/src/components/mushaf/tafsir/TafsirBottomSheet.tsx
+++ b/src/components/mushaf/tafsir/TafsirBottomSheet.tsx
@@ -131,6 +131,8 @@ export default function TafsirBottomSheet({
             <button
               type="button"
               onClick={() => setIsResourceOpen(!isResourceOpen)}
+              aria-expanded={isResourceOpen}
+              aria-controls="tafsir-dropdown-menu"
               className="flex h-12 w-full items-center justify-between gap-3 border border-primary/10 bg-card rounded-2xl px-5 text-sm font-bold shadow-sm transition-all hover:bg-primary/5 hover:border-primary/20 active:scale-[0.98] outline-none"
             >
               <span className="truncate text-primary">{selectedTafsir?.name || t.common.loading}</span>
@@ -143,6 +145,7 @@ export default function TafsirBottomSheet({
                   initial={{ opacity: 0, y: 10, scale: 0.95 }}
                   animate={{ opacity: 1, y: 0, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}
+                  id="tafsir-dropdown-menu"
                   className="absolute top-full left-0 right-0 mt-3 z-[var(--z-context-menu)] bg-card/95 backdrop-blur-2xl border border-primary/10 rounded-2xl shadow-[0_20px_60px_-15px_rgba(0,0,0,0.4)] overflow-hidden"
                 >
                   <div className="p-3 border-b border-primary/5">


### PR DESCRIPTION
💡 What
Added missing `aria-controls` attributes to buttons that toggle expandable content, specifically in the Display Settings and Tafsir Bottom Sheet menus. Also added the corresponding `id` attributes to the controlled content sections.

🎯 Why
This improves accessibility by explicitly linking the toggle controls to the content they expand or collapse, which helps screen readers accurately convey the relationship and location of the expanded content to users.

📸 Before/After
No visual changes were made; this is a purely semantic, under-the-hood accessibility enhancement.

♿ Accessibility
- Added `aria-controls` to the font size, page width, reading mode, live preview, and shortcuts toggle buttons in `DisplaySettings.tsx`.
- Assigned unique IDs to their corresponding content containers.
- Added `aria-expanded` and `aria-controls` to the custom resource selector dropdown in `TafsirBottomSheet.tsx` and assigned an ID to the dropdown menu.

---
*PR created automatically by Jules for task [6375546586847630641](https://jules.google.com/task/6375546586847630641) started by @AHKH3*