### PR TITLE
🎨 Palette: Add localized ARIA labels and tooltips to header icons

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -114,14 +114,16 @@ export default function Header() {
             <button
               onClick={toggleLocale}
               className="p-3 rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              aria-label="Toggle language"
+              aria-label={t.nav.toggleLanguage}
+              title={t.nav.toggleLanguage}
             >
               <Languages size={20} />
             </button>
             <button
               onClick={toggleTheme}
               className="p-3 rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              aria-label="Toggle theme"
+              aria-label={t.nav.toggleTheme}
+              title={t.nav.toggleTheme}
             >
               {!mounted ? (
                 <div className="w-5 h-5" /> // Placeholder to prevent layout shift
@@ -144,7 +146,8 @@ export default function Header() {
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               className="md:hidden p-3 rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              aria-label="Toggle menu"
+              aria-label={t.nav.toggleMenu}
+              title={t.nav.toggleMenu}
               aria-expanded={mobileMenuOpen}
               aria-controls="mobile-menu"
             >

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -7,6 +7,9 @@ export const translations = {
       admin: "لوحة التحكم",
       login: "تسجيل الدخول",
       logout: "تسجيل الخروج",
+      toggleLanguage: "تغيير اللغة",
+      toggleTheme: "تبديل المظهر",
+      toggleMenu: "القائمة",
     },
     hero: {
       greeting: "السلام عليكم ورحمة الله وبركاته",
@@ -287,6 +290,9 @@ export const translations = {
       admin: "Dashboard",
       login: "Login",
       logout: "Logout",
+      toggleLanguage: "Toggle language",
+      toggleTheme: "Toggle theme",
+      toggleMenu: "Toggle menu",
     },
     hero: {
       greeting: "Assalamu Alaikum Wa Rahmatullahi Wa Barakatuh",


### PR DESCRIPTION
💡 **What**: Added localized translation keys (`t.nav.toggleLanguage`, `t.nav.toggleTheme`, `t.nav.toggleMenu`) to the icon-only buttons in the navigation header for both `aria-label` and `title` attributes.
🎯 **Why**: Previously, these buttons used hardcoded English `aria-label`s, which is poorly accessible for Arabic users. Providing localized `aria-label`s enables screen readers to correctly read the button purpose. Adding the `title` attribute adds a hover tooltip, making the function of icon-only buttons discoverable for sighted users.
📸 **Before/After**: See attached frontend verification screenshots showing the English hover states!
♿ **Accessibility**: Significant improvement for screen reader users and visual discoverability on desktop devices.

Created an entry in `.Jules/palette.md` for learnings regarding localized ARIA label accessibility.

---
*PR created automatically by Jules for task [5713261773487366319](https://jules.google.com/task/5713261773487366319) started by @AHKH3*