### PR TITLE
🎨 Palette: Add ARIA label fallbacks to reusable Mushaf buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fallback ARIA labels in reusable icon components
+**Learning:** Reusable icon button components like `MushafButton` and `MushafCloseButton` are often used with just a `title` prop (for tooltips) but no explicit `aria-label`. This makes them inaccessible to screen readers in those instances.
+**Action:** Always map the `title` prop to `aria-label` as a fallback (e.g., `aria-label={props['aria-label'] || props.title}`) when building reusable icon-button components to guarantee baseline accessibility. Also, semantic ARIA attributes like `aria-pressed` should be mapped from functional props like `active`.

--- a/src/components/mushaf/ui/MushafButton.tsx
+++ b/src/components/mushaf/ui/MushafButton.tsx
@@ -25,6 +25,8 @@ const MushafButton = forwardRef<HTMLButtonElement, MushafButtonProps>(
         return (
             <button
                 ref={ref}
+                aria-label={props["aria-label"] || props.title}
+                aria-pressed={active !== undefined ? active : undefined}
                 className={`${baseClasses} ${variantClasses[variant]} ${className || ""}`.trim()}
                 {...props}
             >

--- a/src/components/mushaf/ui/MushafCloseButton.tsx
+++ b/src/components/mushaf/ui/MushafCloseButton.tsx
@@ -13,6 +13,7 @@ const MushafCloseButton = forwardRef<HTMLButtonElement, MushafCloseButtonProps>(
             <button
                 ref={ref}
                 title={title}
+                aria-label={props["aria-label"] || title}
                 className={`p-2 rounded-xl text-muted-foreground transition-all duration-300 ease-out cursor-pointer active:scale-90 hover:bg-destructive/10 hover:text-destructive group outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 ${className}`.trim()}
                 {...props}
             >


### PR DESCRIPTION
💡 What: Mapped the `title` prop to `aria-label` as a fallback in reusable button components (`MushafButton` and `MushafCloseButton`). Also mapped the `active` state to `aria-pressed` for semantic toggles.
🎯 Why: Reusable icon buttons are frequently used throughout the app with only a `title` (for tooltips), making them invisible or poorly described to screen readers. This guarantees baseline accessibility across dozens of floating panel controls.
📸 Before/After: (Non-visual change, affects DOM structure only)
♿ Accessibility: Ensures all icon buttons provide descriptive labels and explicit pressed states to assistive technologies.

---
*PR created automatically by Jules for task [9855970623078617473](https://jules.google.com/task/9855970623078617473) started by @AHKH3*