### PR TITLE
🎨 Palette: Add keyboard accessibility to audio sliders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - Accessible Div-Based Sliders & RTL Navigation
+**Learning:** When turning arbitrary `<div>` elements into custom UI sliders, it's essential to supply standard ARIA slider attributes (`role="slider"`, `tabIndex={0}`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`). More importantly for apps supporting Arabic/RTL, keyboard event handlers (`onKeyDown`) for `ArrowLeft` and `ArrowRight` must be dynamically reversed based on the `isRtl` state to ensure the increment/decrement actions naturally map to the visual layout.
+**Action:** Always provide explicit ARIA roles and RTL-aware `onKeyDown` handlers with proper focus-visible styles when upgrading custom `div` blocks into interactive control mechanisms like volume and progress sliders.

--- a/src/components/mushaf/FloatingAudioPlayer.tsx
+++ b/src/components/mushaf/FloatingAudioPlayer.tsx
@@ -109,7 +109,13 @@ export default function FloatingAudioPlayer({
   const VolumeIcon =
     audioVolume === 0 ? VolumeX : audioVolume < 0.5 ? Volume1 : Volume2;
 
-  const progressPercent = Math.max(0, Math.min(100, audioDuration > 0 ? (audioCurrentTime / audioDuration) * 100 : 0));
+  const progressPercent = Math.max(
+    0,
+    Math.min(
+      100,
+      audioDuration > 0 ? (audioCurrentTime / audioDuration) * 100 : 0,
+    ),
+  );
 
   return (
     <FloatingPanel
@@ -122,8 +128,11 @@ export default function FloatingAudioPlayer({
       defaultPanelHeight={320}
       zIndex={60}
     >
-      <div data-testid="mushaf-audio-panel" className="flex flex-col gap-5 p-5" dir={isRtl ? "rtl" : "ltr"}>
-        
+      <div
+        data-testid="mushaf-audio-panel"
+        className="flex flex-col gap-5 p-5"
+        dir={isRtl ? "rtl" : "ltr"}
+      >
         {/* Top: Reciter Selection (Engraved Pill) */}
         <div className="mushaf-engraved-container flex items-center rounded-2xl transition-all focus-within:shadow-[inset_0_4px_8px_-2px_rgba(0,0,0,0.15)] focus-within:border-primary/40 relative">
           <div className="px-4 flex items-center justify-center text-primary/40">
@@ -136,12 +145,18 @@ export default function FloatingAudioPlayer({
             dir={isRtl ? "rtl" : "ltr"}
           >
             {RECITERS.map((r) => (
-              <option key={r.id} value={r.id} className="bg-card text-foreground font-bold py-2">
+              <option
+                key={r.id}
+                value={r.id}
+                className="bg-card text-foreground font-bold py-2"
+              >
                 {isRtl ? `${r.name}` : `${r.nameEn}`}
               </option>
             ))}
           </select>
-          <div className={`absolute pointer-events-none flex items-center justify-center p-3 text-primary/50 ${isRtl ? "left-2" : "right-2"}`}>
+          <div
+            className={`absolute pointer-events-none flex items-center justify-center p-3 text-primary/50 ${isRtl ? "left-2" : "right-2"}`}
+          >
             <ChevronDown size={16} />
           </div>
         </div>
@@ -156,13 +171,21 @@ export default function FloatingAudioPlayer({
             {currentVerseKey ? (
               <>
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-primary/10 border border-primary/20 shadow-sm backdrop-blur-sm">
-                  <div className={`w-2 h-2 rounded-full ${isPlaying ? 'bg-primary animate-pulse' : 'bg-primary/50'}`} />
-                  <span className="mushaf-text-meta font-black text-primary tracking-[0.1em]" dir="ltr">
+                  <div
+                    className={`w-2 h-2 rounded-full ${isPlaying ? "bg-primary animate-pulse" : "bg-primary/50"}`}
+                  />
+                  <span
+                    className="mushaf-text-meta font-black text-primary tracking-[0.1em]"
+                    dir="ltr"
+                  >
                     {currentVerseKey}
                   </span>
                 </div>
                 {currentVerseText && (
-                  <p className="text-xl sm:text-2xl text-foreground/90 font-['Amiri',serif] leading-relaxed text-center line-clamp-3 drop-shadow-sm px-2 transition-all" dir="rtl">
+                  <p
+                    className="text-xl sm:text-2xl text-foreground/90 font-['Amiri',serif] leading-relaxed text-center line-clamp-3 drop-shadow-sm px-2 transition-all"
+                    dir="rtl"
+                  >
                     {currentVerseText}
                   </p>
                 )}
@@ -170,7 +193,9 @@ export default function FloatingAudioPlayer({
             ) : (
               <div className="flex flex-col items-center gap-3 opacity-40 py-6">
                 <Music2 size={32} className="animate-bounce" />
-                <p className="text-sm font-bold tracking-wide">{t.mushaf.noVerseSelected}</p>
+                <p className="text-sm font-bold tracking-wide">
+                  {t.mushaf.noVerseSelected}
+                </p>
               </div>
             )}
           </div>
@@ -178,13 +203,46 @@ export default function FloatingAudioPlayer({
           {/* Progress Bar (Integrated inside the card) */}
           <div className="w-full flex flex-col gap-2 relative z-10">
             <div
-              className="relative h-3 w-full bg-black/5 dark:bg-white/5 rounded-full cursor-pointer group flex items-center overflow-visible border border-primary/5 shadow-inner"
+              role="slider"
+              tabIndex={0}
+              aria-valuemin={0}
+              aria-valuemax={audioDuration || 0}
+              aria-valuenow={audioCurrentTime}
+              aria-label={t.mushaf.progress}
+              className="relative h-3 w-full bg-black/5 dark:bg-white/5 rounded-full cursor-pointer group flex items-center overflow-visible border border-primary/5 shadow-inner focus-visible:ring-2 focus-visible:ring-primary/50 outline-none"
               onClick={(e) => {
                 if (!audioDuration) return;
                 const rect = e.currentTarget.getBoundingClientRect();
-                const clickX = isRtl ? rect.right - e.clientX : e.clientX - rect.left;
+                const clickX = isRtl
+                  ? rect.right - e.clientX
+                  : e.clientX - rect.left;
                 const ratio = Math.max(0, Math.min(1, clickX / rect.width));
                 onSeek(ratio * audioDuration);
+              }}
+              onKeyDown={(e) => {
+                if (!audioDuration) return;
+                let newTime = audioCurrentTime;
+                const step = 5; // 5 seconds
+                if (e.key === "ArrowRight") {
+                  newTime = isRtl
+                    ? audioCurrentTime - step
+                    : audioCurrentTime + step;
+                  e.preventDefault();
+                } else if (e.key === "ArrowLeft") {
+                  newTime = isRtl
+                    ? audioCurrentTime + step
+                    : audioCurrentTime - step;
+                  e.preventDefault();
+                } else if (e.key === "ArrowUp") {
+                  newTime = audioCurrentTime + step;
+                  e.preventDefault();
+                } else if (e.key === "ArrowDown") {
+                  newTime = audioCurrentTime - step;
+                  e.preventDefault();
+                }
+                if (newTime !== audioCurrentTime) {
+                  onSeek(Math.max(0, Math.min(audioDuration, newTime)));
+                }
               }}
             >
               <div
@@ -193,7 +251,9 @@ export default function FloatingAudioPlayer({
               />
               <div
                 className="absolute w-4 h-4 bg-white dark:bg-primary shadow-[0_2px_10px_rgba(var(--color-primary-rgb),0.5)] rounded-full opacity-0 scale-50 group-hover:opacity-100 group-hover:scale-100 transition-all duration-200"
-                style={{ [isRtl ? "right" : "left"]: `calc(${progressPercent}% - 8px)` }}
+                style={{
+                  [isRtl ? "right" : "left"]: `calc(${progressPercent}% - 8px)`,
+                }}
               />
             </div>
             <div className="flex justify-between items-center text-[11px] font-black text-primary/50 tabular-nums px-1 tracking-widest">
@@ -219,9 +279,17 @@ export default function FloatingAudioPlayer({
             title={isPlaying ? t.mushaf.pause : t.mushaf.audio}
           >
             {isPlaying ? (
-              <Pause size={34} fill="currentColor" className="animate-in fade-in zoom-in duration-300" />
+              <Pause
+                size={34}
+                fill="currentColor"
+                className="animate-in fade-in zoom-in duration-300"
+              />
             ) : (
-              <Play size={34} fill="currentColor" className="translate-x-1 animate-in fade-in zoom-in duration-300" />
+              <Play
+                size={34}
+                fill="currentColor"
+                className="translate-x-1 animate-in fade-in zoom-in duration-300"
+              />
             )}
           </button>
 
@@ -244,10 +312,19 @@ export default function FloatingAudioPlayer({
             className={`min-w-10 h-10 px-3 py-0 rounded-xl flex items-center justify-center transition-all ${repeatMode !== "none" ? "shadow-md" : ""}`}
             title="Toggle Repeat Mode"
           >
-            <RepeatIcon size={16} className={repeatMode !== "none" ? "animate-spin-slow" : ""} />
+            <RepeatIcon
+              size={16}
+              className={repeatMode !== "none" ? "animate-spin-slow" : ""}
+            />
             {repeatMode !== "none" && (
               <span className="text-[10px] sm:text-[11px] font-black tracking-wider uppercase ml-1.5 rtl:ml-0 rtl:mr-1.5">
-                {repeatMode === "one" ? "ONE" : repeatMode === "all" ? "ALL" : repeatMode === "verse" ? "VERSE" : "RANGE"}
+                {repeatMode === "one"
+                  ? "ONE"
+                  : repeatMode === "all"
+                    ? "ALL"
+                    : repeatMode === "verse"
+                      ? "VERSE"
+                      : "RANGE"}
               </span>
             )}
           </MushafButton>
@@ -275,114 +352,168 @@ export default function FloatingAudioPlayer({
             <MushafButton
               variant="icon"
               onClick={() => onSetVolume(audioVolume > 0 ? 0 : 1)}
-              icon={<VolumeIcon size={16} className="text-primary/70 group-hover:text-primary transition-colors" />}
+              icon={
+                <VolumeIcon
+                  size={16}
+                  className="text-primary/70 group-hover:text-primary transition-colors"
+                />
+              }
               className="w-8 h-8 p-0 rounded-lg"
+              title={t.mushaf.volume}
+              aria-label={t.mushaf.volume}
             />
-            <div 
-              className="w-16 sm:w-20 h-2 bg-primary/10 rounded-full cursor-pointer relative overflow-hidden"
+            <div
+              role="slider"
+              tabIndex={0}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(audioVolume * 100)}
+              aria-label={t.mushaf.volume}
+              className="w-16 sm:w-20 h-2 bg-primary/10 rounded-full cursor-pointer relative overflow-hidden focus-visible:ring-2 focus-visible:ring-primary/50 outline-none"
               onClick={(e) => {
                 const rect = e.currentTarget.getBoundingClientRect();
-                const clickX = isRtl ? rect.right - e.clientX : e.clientX - rect.left;
+                const clickX = isRtl
+                  ? rect.right - e.clientX
+                  : e.clientX - rect.left;
                 onSetVolume(Math.max(0, Math.min(1, clickX / rect.width)));
               }}
+              onKeyDown={(e) => {
+                let newVolume = audioVolume;
+                const step = 0.1;
+                if (e.key === "ArrowRight") {
+                  newVolume = isRtl ? audioVolume - step : audioVolume + step;
+                  e.preventDefault();
+                } else if (e.key === "ArrowLeft") {
+                  newVolume = isRtl ? audioVolume + step : audioVolume - step;
+                  e.preventDefault();
+                } else if (e.key === "ArrowUp") {
+                  newVolume = audioVolume + step;
+                  e.preventDefault();
+                } else if (e.key === "ArrowDown") {
+                  newVolume = audioVolume - step;
+                  e.preventDefault();
+                }
+                if (newVolume !== audioVolume) {
+                  onSetVolume(Math.max(0, Math.min(1, newVolume)));
+                }
+              }}
             >
-              <div 
+              <div
                 className="absolute inset-y-0 start-0 bg-primary/70 group-hover:bg-primary transition-all rounded-full"
                 style={{ width: `${audioVolume * 100}%` }}
               />
             </div>
           </div>
 
-          {(repeatMode === "verse" || repeatMode === "range") && onSetVerseRepeatCount && (
-            <>
-              <div className="w-px h-6 bg-primary/10 mx-1" />
-              <MushafButton
-                variant={showAdvancedRepeat ? "primary" : "ghost"}
-                active={showAdvancedRepeat}
-                onClick={() => setShowAdvancedRepeat(!showAdvancedRepeat)}
-                icon={showAdvancedRepeat ? <ChevronUp size={16} /> : <Settings2 size={16} />}
-                className="w-10 h-10 p-0 rounded-xl"
-              />
-            </>
-          )}
+          {(repeatMode === "verse" || repeatMode === "range") &&
+            onSetVerseRepeatCount && (
+              <>
+                <div className="w-px h-6 bg-primary/10 mx-1" />
+                <MushafButton
+                  variant={showAdvancedRepeat ? "primary" : "ghost"}
+                  active={showAdvancedRepeat}
+                  onClick={() => setShowAdvancedRepeat(!showAdvancedRepeat)}
+                  icon={
+                    showAdvancedRepeat ? (
+                      <ChevronUp size={16} />
+                    ) : (
+                      <Settings2 size={16} />
+                    )
+                  }
+                  className="w-10 h-10 p-0 rounded-xl"
+                />
+              </>
+            )}
         </div>
 
         {/* Advanced Repeat Settings Expansion */}
         <AnimatePresence>
-          {showAdvancedRepeat && (repeatMode === "verse" || repeatMode === "range") && (
-            <motion.div
-              initial={{ height: 0, opacity: 0, scale: 0.95 }}
-              animate={{ height: "auto", opacity: 1, scale: 1 }}
-              exit={{ height: 0, opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
-              className="mushaf-engraved-container p-4 rounded-2xl space-y-4 shadow-inner"
-            >
-              {repeatMode === "verse" && onSetVerseRepeatCount && (
-                <div className="space-y-3">
-                  <label className="text-[11px] font-black text-primary/60 uppercase tracking-widest flex items-center gap-2 px-1">
-                    <Repeat size={14} className="text-primary/70" />
-                    {locale === "ar" ? "تكرار كل آية" : "Repeat each verse"}
-                  </label>
-                  <div className="grid grid-cols-5 gap-2">
-                    {[1, 2, 3, 5, 10].map((count) => (
-                      <MushafButton
-                        key={count}
-                        variant={verseRepeatCount === count ? "primary" : "ghost"}
-                        onClick={() => onSetVerseRepeatCount(count)}
-                        className={`h-9 px-0 text-xs font-bold rounded-xl flex items-center justify-center ${verseRepeatCount === count ? "shadow-md" : "bg-card/50"}`}
-                      >
-                        {count}×
-                      </MushafButton>
-                    ))}
+          {showAdvancedRepeat &&
+            (repeatMode === "verse" || repeatMode === "range") && (
+              <motion.div
+                initial={{ height: 0, opacity: 0, scale: 0.95 }}
+                animate={{ height: "auto", opacity: 1, scale: 1 }}
+                exit={{ height: 0, opacity: 0, scale: 0.95 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+                className="mushaf-engraved-container p-4 rounded-2xl space-y-4 shadow-inner"
+              >
+                {repeatMode === "verse" && onSetVerseRepeatCount && (
+                  <div className="space-y-3">
+                    <label className="text-[11px] font-black text-primary/60 uppercase tracking-widest flex items-center gap-2 px-1">
+                      <Repeat size={14} className="text-primary/70" />
+                      {locale === "ar" ? "تكرار كل آية" : "Repeat each verse"}
+                    </label>
+                    <div className="grid grid-cols-5 gap-2">
+                      {[1, 2, 3, 5, 10].map((count) => (
+                        <MushafButton
+                          key={count}
+                          variant={
+                            verseRepeatCount === count ? "primary" : "ghost"
+                          }
+                          onClick={() => onSetVerseRepeatCount(count)}
+                          className={`h-9 px-0 text-xs font-bold rounded-xl flex items-center justify-center ${verseRepeatCount === count ? "shadow-md" : "bg-card/50"}`}
+                        >
+                          {count}×
+                        </MushafButton>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
 
-              {repeatMode === "range" && onSetRangeRepeatCount && (
-                <div className="space-y-3">
-                  <label className="text-[11px] font-black text-primary/60 uppercase tracking-widest flex items-center gap-2 px-1">
-                    <Repeat size={14} className="text-primary/70" />
-                    {locale === "ar" ? "تكرار المدى" : "Repeat range"}
-                  </label>
-                  <div className="grid grid-cols-5 gap-2">
-                    {[1, 2, 3, 5, 10].map((count) => (
-                      <MushafButton
-                        key={count}
-                        variant={rangeRepeatCount === count ? "primary" : "ghost"}
-                        onClick={() => onSetRangeRepeatCount(count)}
-                        className={`h-9 px-0 text-xs font-bold rounded-xl flex items-center justify-center ${rangeRepeatCount === count ? "shadow-md" : "bg-card/50"}`}
-                      >
-                        {count}×
-                      </MushafButton>
-                    ))}
+                {repeatMode === "range" && onSetRangeRepeatCount && (
+                  <div className="space-y-3">
+                    <label className="text-[11px] font-black text-primary/60 uppercase tracking-widest flex items-center gap-2 px-1">
+                      <Repeat size={14} className="text-primary/70" />
+                      {locale === "ar" ? "تكرار المدى" : "Repeat range"}
+                    </label>
+                    <div className="grid grid-cols-5 gap-2">
+                      {[1, 2, 3, 5, 10].map((count) => (
+                        <MushafButton
+                          key={count}
+                          variant={
+                            rangeRepeatCount === count ? "primary" : "ghost"
+                          }
+                          onClick={() => onSetRangeRepeatCount(count)}
+                          className={`h-9 px-0 text-xs font-bold rounded-xl flex items-center justify-center ${rangeRepeatCount === count ? "shadow-md" : "bg-card/50"}`}
+                        >
+                          {count}×
+                        </MushafButton>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
 
-              {onSetPauseBetweenVerses && (
-                <div className="space-y-3 pt-1 border-t border-primary/10">
-                  <label className="text-[11px] font-black text-primary/60 uppercase tracking-widest flex items-center gap-2 px-1 pt-1">
-                    <Timer size={14} className="text-primary/70" />
-                    {locale === "ar" ? "وقفة بين الآيات" : "Pause between verses"}
-                  </label>
-                  <div className="grid grid-cols-5 gap-2">
-                    {[0, 1, 2, 3, 5].map((seconds) => (
-                      <MushafButton
-                        key={seconds}
-                        variant={pauseBetweenVerses === seconds ? "primary" : "ghost"}
-                        onClick={() => onSetPauseBetweenVerses(seconds)}
-                        className={`h-9 px-0 text-xs font-bold rounded-xl flex items-center justify-center ${pauseBetweenVerses === seconds ? "shadow-md" : "bg-card/50"}`}
-                      >
-                        {seconds === 0 ? (locale === "ar" ? "0" : "0") : `${seconds}s`}
-                      </MushafButton>
-                    ))}
+                {onSetPauseBetweenVerses && (
+                  <div className="space-y-3 pt-1 border-t border-primary/10">
+                    <label className="text-[11px] font-black text-primary/60 uppercase tracking-widest flex items-center gap-2 px-1 pt-1">
+                      <Timer size={14} className="text-primary/70" />
+                      {locale === "ar"
+                        ? "وقفة بين الآيات"
+                        : "Pause between verses"}
+                    </label>
+                    <div className="grid grid-cols-5 gap-2">
+                      {[0, 1, 2, 3, 5].map((seconds) => (
+                        <MushafButton
+                          key={seconds}
+                          variant={
+                            pauseBetweenVerses === seconds ? "primary" : "ghost"
+                          }
+                          onClick={() => onSetPauseBetweenVerses(seconds)}
+                          className={`h-9 px-0 text-xs font-bold rounded-xl flex items-center justify-center ${pauseBetweenVerses === seconds ? "shadow-md" : "bg-card/50"}`}
+                        >
+                          {seconds === 0
+                            ? locale === "ar"
+                              ? "0"
+                              : "0"
+                            : `${seconds}s`}
+                        </MushafButton>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
-            </motion.div>
-          )}
+                )}
+              </motion.div>
+            )}
         </AnimatePresence>
-
       </div>
     </FloatingPanel>
   );


### PR DESCRIPTION
### 💡 What
Upgraded the custom div-based progress and volume sliders in the `FloatingAudioPlayer` component into fully accessible ARIA sliders. Added RTL-aware keyboard navigation bindings (`onKeyDown`). Added an explicit `aria-label` and `title` to the volume icon button.

### 🎯 Why
Custom `div` elements visually act as sliders but are invisible to screen readers and inaccessible to keyboard users without explicit ARIA roles, tabindex, and keyboard event handlers. The keyboard logic needed to properly account for Right-to-Left (RTL) reading modes (Arabic) so that Left/Right arrow keys dynamically reversed their logic to match the visual UI direction.

### 📸 Before/After
**Before:** Sliders could only be interacted with via mouse clicks. `Tab` key completely skipped them.
**After:** Sliders are fully focusable via the `Tab` key (with a visible `focus-visible` outline). Users can increment/decrement volume by `0.1` or progress by `5` seconds using Arrow keys, gracefully supporting both RTL and LTR layouts.

### ♿ Accessibility
- Added `role="slider"`, `tabIndex={0}`, `aria-valuemin`, `aria-valuemax`, and `aria-valuenow`.
- Mapped `ArrowUp/ArrowDown` and `ArrowLeft/ArrowRight` correctly.
- Reversed increment/decrement logic for Horizontal arrows based on the `isRtl` property.
- Ensured visual `focus-visible` indicators for keyboard focus without impacting mouse clicks.
- Added `title` and `aria-label` to the volume button.

---
*PR created automatically by Jules for task [6006625777618209158](https://jules.google.com/task/6006625777618209158) started by @AHKH3*