### PR TITLE
🎨 Palette: Improve MushafButton accessibility with aria fallbacks

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-07 - MushafButton Accessibility Insights
+**Learning:** Found that custom reusable UI elements often lack robust fallback accessibility attributes natively provided by semantic HTML.
+**Action:** When building reusable UI elements (e.g., `MushafButton`), map `title` to `aria-label` as a fallback and visual active props to `aria-pressed` to guarantee accessibility for screen readers and semantic ARIA translation.

--- a/src/components/mushaf/ui/MushafButton.tsx
+++ b/src/components/mushaf/ui/MushafButton.tsx
@@ -27,6 +27,8 @@ const MushafButton = forwardRef<HTMLButtonElement, MushafButtonProps>(
                 ref={ref}
                 className={`${baseClasses} ${variantClasses[variant]} ${className || ""}`.trim()}
                 {...props}
+                aria-label={props['aria-label'] || props.title}
+                aria-pressed={active !== undefined ? active : undefined}
             >
                 {/* Icon wrapper with hover animation */}
                 {icon && (


### PR DESCRIPTION
💡 What:
Added fallback `aria-label` mapping to the `title` prop and an explicit `aria-pressed` mapping to the `active` prop in the `MushafButton` component.

🎯 Why:
To ensure icon-only buttons remain accessible to screen readers even when an explicit `aria-label` is forgotten by the developer, and to semantically announce the toggled/pressed state of the button.

📸 Before/After:
No visual changes. Purely semantic HTML improvements.

♿ Accessibility:
Ensures all instances of `MushafButton` (which are used heavily across the Mushaf viewer) have a baseline accessible name and state reporting for assistive technologies.

---
*PR created automatically by Jules for task [12490594328087800518](https://jules.google.com/task/12490594328087800518) started by @AHKH3*